### PR TITLE
Add Go OpenAI API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Hoping these referene code can be useful to you.
 ### [learngo/ai/groq-ai](https://github.com/donvito/learngo/tree/master/ai/go-groq)
 This example shows how translate text using the Groq's Fast Inference API.
 Check out the full tutorial in my [blog post](https://blog.donvitocodes.com/using-go-to-translate-text-using-the-groq-api-fast-inference).
+
+### [learngo/ai/go-openai](https://github.com/donvito/learngo/tree/master/ai/go-openai)
+This example shows how to call the OpenAI Chat Completions API using Go's standard library.

--- a/ai/go-openai/go.mod
+++ b/ai/go-openai/go.mod
@@ -1,0 +1,3 @@
+module go-openai
+
+go 1.22

--- a/ai/go-openai/main.go
+++ b/ai/go-openai/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		err := errors.New("OPENAI_API_KEY needs to be set as an environment variable")
+		panic(err)
+	}
+
+	openAIClient := &OpenAIClient{APIKey: apiKey}
+
+	systemPrompt := "You are a helpful assistant. Keep your answer concise."
+	prompt := "Explain why Go is a good language for building API clients."
+
+	response, err := openAIClient.ChatCompletion(defaultOpenAIModel, systemPrompt, prompt)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if response != nil {
+		fmt.Println(*response)
+	}
+}

--- a/ai/go-openai/openai_client.go
+++ b/ai/go-openai/openai_client.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultOpenAIBaseURL = "https://api.openai.com"
+	defaultOpenAIModel   = "gpt-4o-mini"
+
+	roleSystem = "system"
+	roleUser   = "user"
+)
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type OpenAIClient struct {
+	APIKey     string
+	BaseURL    string
+	HTTPClient HTTPClient
+}
+
+type OpenAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatCompletionRequest struct {
+	Model       string          `json:"model"`
+	Messages    []OpenAIMessage `json:"messages"`
+	Temperature float64         `json:"temperature"`
+	MaxTokens   int             `json:"max_tokens"`
+}
+
+type ChatCompletionResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+func (c *OpenAIClient) ChatCompletion(model string, systemPrompt string, prompt string) (*string, error) {
+	if strings.TrimSpace(c.APIKey) == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	if strings.TrimSpace(prompt) == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	if model == "" {
+		model = defaultOpenAIModel
+	}
+
+	messages := make([]OpenAIMessage, 0, 2)
+	if systemPrompt != "" {
+		messages = append(messages, OpenAIMessage{
+			Role:    roleSystem,
+			Content: systemPrompt,
+		})
+	}
+
+	messages = append(messages, OpenAIMessage{
+		Role:    roleUser,
+		Content: prompt,
+	})
+
+	requestBody := &ChatCompletionRequest{
+		Model:       model,
+		Messages:    messages,
+		Temperature: 0.7,
+		MaxTokens:   300,
+	}
+
+	encodedBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.chatCompletionsURL(), bytes.NewBuffer(encodedBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, string(body))
+	}
+
+	chatCompletionResp := &ChatCompletionResponse{}
+	if err := json.Unmarshal(body, chatCompletionResp); err != nil {
+		return nil, err
+	}
+
+	if len(chatCompletionResp.Choices) == 0 {
+		return nil, fmt.Errorf("no choices returned")
+	}
+
+	content := chatCompletionResp.Choices[0].Message.Content
+	return &content, nil
+}
+
+func (c *OpenAIClient) chatCompletionsURL() string {
+	baseURL := strings.TrimRight(c.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = defaultOpenAIBaseURL
+	}
+
+	return fmt.Sprintf("%s/v1/chat/completions", baseURL)
+}

--- a/ai/go-openai/openai_client_test.go
+++ b/ai/go-openai/openai_client_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestChatCompletionSendsRequestAndReturnsContent(t *testing.T) {
+	var request ChatCompletionRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected method %s, got %s", http.MethodPost, r.Method)
+		}
+
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("expected path /v1/chat/completions, got %s", r.URL.Path)
+		}
+
+		if got := r.Header.Get("Authorization"); got != "Bearer test-api-key" {
+			t.Errorf("expected authorization bearer token, got %q", got)
+		}
+
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("expected application/json content type, got %q", got)
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-test",
+			"object": "chat.completion",
+			"created": 1710000000,
+			"model": "gpt-4o-mini",
+			"choices": [
+				{
+					"index": 0,
+					"message": {
+						"role": "assistant",
+						"content": "Go is concise and ships with a strong standard library."
+					},
+					"finish_reason": "stop"
+				}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	content, err := client.ChatCompletion("", "You are concise.", "Why use Go for API clients?")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if content == nil {
+		t.Fatal("expected content, got nil")
+	}
+
+	if *content != "Go is concise and ships with a strong standard library." {
+		t.Errorf("unexpected content: %q", *content)
+	}
+
+	if request.Model != defaultOpenAIModel {
+		t.Errorf("expected default model %q, got %q", defaultOpenAIModel, request.Model)
+	}
+
+	if len(request.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(request.Messages))
+	}
+
+	if request.Messages[0].Role != roleSystem || request.Messages[0].Content != "You are concise." {
+		t.Errorf("unexpected system message: %+v", request.Messages[0])
+	}
+
+	if request.Messages[1].Role != roleUser || request.Messages[1].Content != "Why use Go for API clients?" {
+		t.Errorf("unexpected user message: %+v", request.Messages[1])
+	}
+}
+
+func TestChatCompletionRequiresAPIKey(t *testing.T) {
+	client := &OpenAIClient{}
+
+	content, err := client.ChatCompletion(defaultOpenAIModel, "", "Hello")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if content != nil {
+		t.Fatalf("expected nil content, got %q", *content)
+	}
+
+	if !strings.Contains(err.Error(), "api key is required") {
+		t.Errorf("expected api key error, got %v", err)
+	}
+}
+
+func TestChatCompletionRequiresPrompt(t *testing.T) {
+	client := &OpenAIClient{APIKey: "test-api-key"}
+
+	content, err := client.ChatCompletion(defaultOpenAIModel, "", " ")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if content != nil {
+		t.Fatalf("expected nil content, got %q", *content)
+	}
+
+	if !strings.Contains(err.Error(), "prompt is required") {
+		t.Errorf("expected prompt error, got %v", err)
+	}
+}
+
+func TestChatCompletionReturnsErrorForUnexpectedStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	content, err := client.ChatCompletion(defaultOpenAIModel, "", "Hello")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if content != nil {
+		t.Fatalf("expected nil content, got %q", *content)
+	}
+
+	if !strings.Contains(err.Error(), "unexpected status code: 400") {
+		t.Errorf("expected status code error, got %v", err)
+	}
+}
+
+func TestChatCompletionReturnsErrorWhenChoicesAreMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	content, err := client.ChatCompletion(defaultOpenAIModel, "", "Hello")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if content != nil {
+		t.Fatalf("expected nil content, got %q", *content)
+	}
+
+	if !strings.Contains(err.Error(), "no choices returned") {
+		t.Errorf("expected no choices error, got %v", err)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a new `ai/go-openai` example module for calling the OpenAI Chat Completions API from Go.
- Include a small standard-library client and runnable `main.go` using `OPENAI_API_KEY`.
- Add unit tests for request construction, validation, API errors, and missing choices.

## Tests
- `go test ./...` from `ai/go-openai`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d75dbbf1-1481-4aa8-9b00-d9344b625ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d75dbbf1-1481-4aa8-9b00-d9344b625ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

