### PR TITLE
Add OpenAI Go API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Hoping these referene code can be useful to you.
 ### [learngo/ai/groq-ai](https://github.com/donvito/learngo/tree/master/ai/go-groq)
 This example shows how translate text using the Groq's Fast Inference API.
 Check out the full tutorial in my [blog post](https://blog.donvitocodes.com/using-go-to-translate-text-using-the-groq-api-fast-inference).
+
+### [learngo/ai/go-openai](https://github.com/donvito/learngo/tree/master/ai/go-openai)
+This example shows how to call the OpenAI Chat Completions API using Go.

--- a/ai/go-openai/go.mod
+++ b/ai/go-openai/go.mod
@@ -1,0 +1,3 @@
+module go-openai
+
+go 1.22

--- a/ai/go-openai/main.go
+++ b/ai/go-openai/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		panic(errors.New("OPENAI_API_KEY needs to be set as an environment variable"))
+	}
+
+	openAIClient := &OpenAIClient{APIKey: apiKey}
+	systemPrompt := "you are a helpful assistant. answer clearly and concisely."
+	prompt := "write a one sentence explanation of why unit tests are useful in Go"
+
+	response, err := openAIClient.ChatCompletion("", systemPrompt, prompt)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if response != nil {
+		fmt.Println(*response)
+	}
+}

--- a/ai/go-openai/openai_client.go
+++ b/ai/go-openai/openai_client.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultOpenAIBaseURL = "https://api.openai.com"
+	defaultOpenAIModel   = "gpt-4o-mini"
+
+	roleSystem = "system"
+	roleUser   = "user"
+)
+
+type OpenAIClient struct {
+	APIKey     string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+type OpenAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatCompletionRequest struct {
+	Model       string          `json:"model"`
+	Messages    []OpenAIMessage `json:"messages"`
+	Temperature float64         `json:"temperature"`
+	MaxTokens   int             `json:"max_tokens"`
+}
+
+type ChatCompletionResponse struct {
+	Choices []struct {
+		Message OpenAIMessage `json:"message"`
+	} `json:"choices"`
+}
+
+func (c *OpenAIClient) ChatCompletion(model string, systemPrompt string, prompt string) (*string, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	selectedModel := model
+	if selectedModel == "" {
+		selectedModel = defaultOpenAIModel
+	}
+
+	messages := make([]OpenAIMessage, 0, 2)
+	if systemPrompt != "" {
+		messages = append(messages, OpenAIMessage{
+			Role:    roleSystem,
+			Content: systemPrompt,
+		})
+	}
+
+	messages = append(messages, OpenAIMessage{
+		Role:    roleUser,
+		Content: prompt,
+	})
+
+	chatCompletionRequest := &ChatCompletionRequest{
+		Model:       selectedModel,
+		Messages:    messages,
+		Temperature: 0,
+		MaxTokens:   1024,
+	}
+
+	requestBody, err := json.Marshal(chatCompletionRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.chatCompletionURL(), bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	chatCompletionResponse := &ChatCompletionResponse{}
+	if err := json.Unmarshal(body, chatCompletionResponse); err != nil {
+		return nil, err
+	}
+
+	if len(chatCompletionResponse.Choices) == 0 {
+		return nil, fmt.Errorf("no choices")
+	}
+
+	content := chatCompletionResponse.Choices[0].Message.Content
+	return &content, nil
+}
+
+func (c *OpenAIClient) chatCompletionURL() string {
+	baseURL := c.BaseURL
+	if baseURL == "" {
+		baseURL = defaultOpenAIBaseURL
+	}
+
+	return fmt.Sprintf("%s/v1/chat/completions", strings.TrimRight(baseURL, "/"))
+}

--- a/ai/go-openai/openai_client_test.go
+++ b/ai/go-openai/openai_client_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestChatCompletionSendsRequestAndReturnsContent(t *testing.T) {
+	t.Parallel()
+
+	requestChecked := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("expected path /v1/chat/completions, got %s", r.URL.Path)
+		}
+
+		if r.Method != http.MethodPost {
+			t.Errorf("expected method POST, got %s", r.Method)
+		}
+
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("expected content type application/json, got %s", got)
+		}
+
+		if got := r.Header.Get("Authorization"); got != "Bearer test-api-key" {
+			t.Errorf("expected authorization header Bearer test-api-key, got %s", got)
+		}
+
+		var req ChatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		if req.Model != "gpt-4.1-mini" {
+			t.Errorf("expected model gpt-4.1-mini, got %s", req.Model)
+		}
+
+		if req.Temperature != 0 {
+			t.Errorf("expected temperature 0, got %f", req.Temperature)
+		}
+
+		if req.MaxTokens != 1024 {
+			t.Errorf("expected max tokens 1024, got %d", req.MaxTokens)
+		}
+
+		expectedMessages := []OpenAIMessage{
+			{Role: roleSystem, Content: "be brief"},
+			{Role: roleUser, Content: "say hello"},
+		}
+
+		if len(req.Messages) != len(expectedMessages) {
+			t.Fatalf("expected %d messages, got %d", len(expectedMessages), len(req.Messages))
+		}
+
+		for i, expected := range expectedMessages {
+			if req.Messages[i] != expected {
+				t.Errorf("message %d expected %+v, got %+v", i, expected, req.Messages[i])
+			}
+		}
+
+		requestChecked = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hello from openai"}}]}`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL + "/",
+	}
+
+	content, err := client.ChatCompletion("gpt-4.1-mini", "be brief", "say hello")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if content == nil {
+		t.Fatal("expected content, got nil")
+	}
+
+	if *content != "hello from openai" {
+		t.Errorf("expected response content, got %q", *content)
+	}
+
+	if !requestChecked {
+		t.Fatal("server did not check the request")
+	}
+}
+
+func TestChatCompletionUsesDefaultModel(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		if req.Model != defaultOpenAIModel {
+			t.Errorf("expected default model %s, got %s", defaultOpenAIModel, req.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"default model response"}}]}`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	content, err := client.ChatCompletion("", "", "hello")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if content == nil || *content != "default model response" {
+		t.Fatalf("expected default model response, got %v", content)
+	}
+}
+
+func TestChatCompletionRequiresPrompt(t *testing.T) {
+	t.Parallel()
+
+	client := &OpenAIClient{APIKey: "test-api-key"}
+
+	content, err := client.ChatCompletion("", "", "   ")
+	if err == nil {
+		t.Fatal("expected prompt validation error")
+	}
+
+	if content != nil {
+		t.Fatalf("expected nil content, got %v", *content)
+	}
+
+	if err.Error() != "prompt is required" {
+		t.Fatalf("expected prompt is required error, got %v", err)
+	}
+}
+
+func TestChatCompletionReturnsAPIError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "bad-api-key",
+		BaseURL: server.URL,
+	}
+
+	content, err := client.ChatCompletion("", "", "hello")
+	if err == nil {
+		t.Fatal("expected api error")
+	}
+
+	if content != nil {
+		t.Fatalf("expected nil content, got %v", *content)
+	}
+
+	if !strings.Contains(err.Error(), "unexpected status code: 401") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
+}
+
+func TestChatCompletionReturnsNoChoicesError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	content, err := client.ChatCompletion("", "", "hello")
+	if err == nil {
+		t.Fatal("expected no choices error")
+	}
+
+	if content != nil {
+		t.Fatalf("expected nil content, got %v", *content)
+	}
+
+	if err.Error() != "no choices" {
+		t.Fatalf("expected no choices error, got %v", err)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a standalone `ai/go-openai` module demonstrating OpenAI Chat Completions from Go
- Include a small reusable client and runnable `main` using `OPENAI_API_KEY`
- Add unit tests covering request construction, default model behavior, validation, API errors, and empty choices
- Link the new example from the root README

## Testing
- `go test ./...` from `ai/go-openai`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a450d2c-4c82-4df5-969e-f8edd58a7dd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a450d2c-4c82-4df5-969e-f8edd58a7dd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

