### PR TITLE
Add Go OpenAI API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Hoping these referene code can be useful to you.
 ### [learngo/ai/groq-ai](https://github.com/donvito/learngo/tree/master/ai/go-groq)
 This example shows how translate text using the Groq's Fast Inference API.
 Check out the full tutorial in my [blog post](https://blog.donvitocodes.com/using-go-to-translate-text-using-the-groq-api-fast-inference).
+
+### [learngo/ai/go-openai](https://github.com/donvito/learngo/tree/master/ai/go-openai)
+This example shows how to call the OpenAI Responses API using Go's standard HTTP client.

--- a/ai/go-openai/go.mod
+++ b/ai/go-openai/go.mod
@@ -1,0 +1,3 @@
+module go-openai
+
+go 1.22

--- a/ai/go-openai/main.go
+++ b/ai/go-openai/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		err := errors.New("OPENAI_API_KEY need to be set as an environment variable")
+		panic(err)
+	}
+
+	openAIClient := &OpenAIClient{APIKey: apiKey}
+	instructions := "You are a helpful assistant. Keep the answer short and practical."
+	prompt := "Give me three tips for learning Go."
+
+	response, err := openAIClient.GenerateText(defaultOpenAIModel, instructions, prompt)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(response)
+}

--- a/ai/go-openai/openai_client.go
+++ b/ai/go-openai/openai_client.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	apiBaseURL         = "https://api.openai.com"
+	defaultOpenAIModel = "gpt-4o-mini"
+)
+
+type OpenAIClient struct {
+	APIKey     string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+type ResponsesRequest struct {
+	Model           string `json:"model"`
+	Instructions    string `json:"instructions,omitempty"`
+	Input           string `json:"input"`
+	MaxOutputTokens int    `json:"max_output_tokens,omitempty"`
+}
+
+type ResponsesResponse struct {
+	ID     string `json:"id"`
+	Object string `json:"object"`
+	Model  string `json:"model"`
+	Output []struct {
+		ID      string `json:"id"`
+		Type    string `json:"type"`
+		Status  string `json:"status"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"output"`
+}
+
+type OpenAIErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+func (o *OpenAIClient) GenerateText(model string, instructions string, prompt string) (string, error) {
+	if strings.TrimSpace(o.APIKey) == "" {
+		return "", fmt.Errorf("api key is required")
+	}
+
+	if strings.TrimSpace(prompt) == "" {
+		return "", fmt.Errorf("prompt is required")
+	}
+
+	llm := model
+	if llm == "" {
+		llm = defaultOpenAIModel
+	}
+
+	openAIRequest := &ResponsesRequest{
+		Model:           llm,
+		Instructions:    instructions,
+		Input:           prompt,
+		MaxOutputTokens: 300,
+	}
+
+	openAIRequestJSON, err := json.Marshal(openAIRequest)
+	if err != nil {
+		return "", err
+	}
+
+	baseURL := o.BaseURL
+	if baseURL == "" {
+		baseURL = apiBaseURL
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/v1/responses", strings.TrimRight(baseURL, "/")), bytes.NewBuffer(openAIRequestJSON))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", o.APIKey))
+
+	client := o.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			fmt.Println("Error:", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d, reason: %s, message: %s", resp.StatusCode, resp.Status, parseOpenAIError(body))
+	}
+
+	openAIResponse := &ResponsesResponse{}
+	err = json.Unmarshal(body, openAIResponse)
+	if err != nil {
+		return "", err
+	}
+
+	for _, output := range openAIResponse.Output {
+		for _, content := range output.Content {
+			if content.Text != "" {
+				return content.Text, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no output text")
+}
+
+func parseOpenAIError(body []byte) string {
+	openAIError := &OpenAIErrorResponse{}
+	err := json.Unmarshal(body, openAIError)
+	if err != nil || openAIError.Error.Message == "" {
+		return string(body)
+	}
+
+	return openAIError.Error.Message
+}

--- a/ai/go-openai/openai_client_test.go
+++ b/ai/go-openai/openai_client_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateTextSendsResponsesRequest(t *testing.T) {
+	var request ResponsesRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+
+		if r.URL.Path != "/v1/responses" {
+			t.Errorf("expected /v1/responses path, got %s", r.URL.Path)
+		}
+
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json content type, got %s", r.Header.Get("Content-Type"))
+		}
+
+		if r.Header.Get("Authorization") != "Bearer test-api-key" {
+			t.Errorf("unexpected authorization header: %s", r.Header.Get("Authorization"))
+		}
+
+		err := json.NewDecoder(r.Body).Decode(&request)
+		if err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{
+			"id": "resp_123",
+			"object": "response",
+			"model": "gpt-4o-mini",
+			"output": [
+				{
+					"id": "msg_123",
+					"type": "message",
+					"status": "completed",
+					"content": [
+						{
+							"type": "output_text",
+							"text": "Learn the basics, write small programs, and read standard library docs."
+						}
+					]
+				}
+			]
+		}`))
+		if err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	response, err := client.GenerateText("", "Keep it short.", "How should I learn Go?")
+	if err != nil {
+		t.Fatalf("GenerateText returned error: %v", err)
+	}
+
+	if response != "Learn the basics, write small programs, and read standard library docs." {
+		t.Errorf("unexpected response: %s", response)
+	}
+
+	if request.Model != defaultOpenAIModel {
+		t.Errorf("expected default model %s, got %s", defaultOpenAIModel, request.Model)
+	}
+
+	if request.Instructions != "Keep it short." {
+		t.Errorf("unexpected instructions: %s", request.Instructions)
+	}
+
+	if request.Input != "How should I learn Go?" {
+		t.Errorf("unexpected input: %s", request.Input)
+	}
+
+	if request.MaxOutputTokens != 300 {
+		t.Errorf("expected max output tokens 300, got %d", request.MaxOutputTokens)
+	}
+}
+
+func TestGenerateTextUsesProvidedModel(t *testing.T) {
+	var request ResponsesRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&request)
+		if err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{
+			"output": [
+				{
+					"content": [
+						{
+							"text": "custom model response"
+						}
+					]
+				}
+			]
+		}`))
+		if err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	_, err := client.GenerateText("gpt-4.1-mini", "", "Say hello")
+	if err != nil {
+		t.Fatalf("GenerateText returned error: %v", err)
+	}
+
+	if request.Model != "gpt-4.1-mini" {
+		t.Errorf("expected provided model, got %s", request.Model)
+	}
+}
+
+func TestGenerateTextRequiresAPIKey(t *testing.T) {
+	client := &OpenAIClient{}
+
+	_, err := client.GenerateText("", "", "Say hello")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if err.Error() != "api key is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGenerateTextRequiresPrompt(t *testing.T) {
+	client := &OpenAIClient{APIKey: "test-api-key"}
+
+	_, err := client.GenerateText("", "", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if err.Error() != "prompt is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGenerateTextReturnsOpenAIErrorMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, err := w.Write([]byte(`{
+			"error": {
+				"message": "Incorrect API key provided",
+				"type": "invalid_request_error",
+				"code": "invalid_api_key"
+			}
+		}`))
+		if err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "bad-api-key",
+		BaseURL: server.URL,
+	}
+
+	_, err := client.GenerateText("", "", "Say hello")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "Incorrect API key provided") {
+		t.Errorf("expected OpenAI error message, got %v", err)
+	}
+}
+
+func TestGenerateTextReturnsNoOutputTextError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"output":[]}`))
+		if err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+	}
+
+	_, err := client.GenerateText("", "", "Say hello")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if err.Error() != "no output text" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a standalone `ai/go-openai` example module using the OpenAI Responses API with Go's standard HTTP client
- Include a small `main.go` demonstrating `OPENAI_API_KEY` usage
- Add unit tests with an `httptest` server for request construction, response parsing, and error paths
- Link the new example from the root README

## Testing
- `go test ./...` from `ai/go-openai`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14eab211-5fab-48bd-a414-351ca077de76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14eab211-5fab-48bd-a414-351ca077de76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

