### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+## Cursor Cloud specific instructions
+
+### Repository structure
+
+This is a **learning monorepo** of independent Go example projects. There is **no root `go.mod`** — each subdirectory is a standalone program. Seven subdirectories have their own `go.mod`; the rest are legacy GOPATH-style single-file programs.
+
+### Go modules vs legacy directories
+
+| Type | Directories | How to build/run |
+|---|---|---|
+| **go.mod projects** | `http-server`, `mongo-microservice`, `rest-kafka-mongo-microservice`, `htmx`, `ai/go-groq`, `connect-to-db-postgres`, `docker` | `cd <dir> && go build ./...` or `go run main.go` |
+| **Legacy (no go.mod)** | All others (`helloworld`, `channels`, `closures`, `testing`, `benchmark`, etc.) | `cd <dir> && GO111MODULE=off go run main.go` or `GO111MODULE=off go build .` |
+
+### Running tests
+
+- Unit tests: `cd testing && GO111MODULE=off go test -v .`
+- Benchmarks: `cd benchmark && GO111MODULE=off go test -bench=. .`
+
+### Linting
+
+- `go vet ./...` inside any go.mod directory
+- `staticcheck ./...` (installed in `~/go/bin`) inside any go.mod directory
+- For legacy directories: `cd <dir> && GO111MODULE=off go vet .`
+
+### Running the HTTP server (primary demo app)
+
+```
+cd http-server && go run main.go
+```
+Listens on `:8000`. Verify with `curl http://localhost:8000/` (returns "Hello World").
+
+### External-service-dependent projects (optional)
+
+These projects require external services and are **not** needed for core development:
+
+- `mongo-microservice`, `rest-kafka-mongo-microservice` — need MongoDB (`:27017`); docker-compose at `mongo-microservice/mongodb/docker-compose.yml`
+- `kafka/producer`, `kafka/consumer`, `rest-kafka-mongo-microservice` — need Apache Kafka (`:9092`)
+- `connect-to-db-postgres` — needs PostgreSQL (`:5432`); docker-compose at `.devcontainer/docker-compose.yml`
+- `docker/*` — needs Docker daemon
+- `ai/go-groq`, `htmx` — need `GROQ_API_KEY` env var
+
+### Gotchas
+
+- `pointers/basic/` has multiple files with `main` redeclared — this is a pre-existing repo issue. Build individual files with `GO111MODULE=off go run main.go`.
+- `~/go/bin` must be on `PATH` to use `staticcheck`. It is added via `~/.bashrc`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions for this Go learning monorepo.

### What's included

- Repository structure overview (go.mod projects vs legacy GOPATH-style directories)
- How to build, run, and test each type of project
- Linting instructions (`go vet` and `staticcheck`)
- HTTP server demo app instructions
- Notes on external-service-dependent projects (MongoDB, Kafka, PostgreSQL, Docker, Groq API)
- Known gotchas (e.g. `pointers/basic/` duplicate `main` declarations)

### Evidence of working environment

HTTP server running on `:8000` and responding to requests:

[http_server_hello_world.log](https://cursor.com/agents/bc-70bc67cb-55d1-461c-9f33-d06ff634f6f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhttp_server_hello_world.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70bc67cb-55d1-461c-9f33-d06ff634f6f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70bc67cb-55d1-461c-9f33-d06ff634f6f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

